### PR TITLE
Angular-based Level of Detail (LOD) implementation

### DIFF
--- a/libs/soba/performances/README.md
+++ b/libs/soba/performances/README.md
@@ -16,6 +16,7 @@ npm install three-mesh-bvh
 - [NgtsAdaptiveEvents](#ngtsadaptiveevents)
 - [NgtsBVH](#ngtsbvh)
 - [NgtsDetailed](#ngtsdetailed)
+- [NgtsLOD](#ngtslod)
 - [NgtsInstances](#ngtsinstances)
 - [NgtsSegments](#ngtssegments)
 - [NgtsPoints](#ngtspoints)
@@ -92,6 +93,42 @@ Implements Level of Detail (LOD) rendering. Automatically switches between diffe
 	<ngt-mesh><!-- Medium detail --></ngt-mesh>
 	<ngt-mesh><!-- Low detail --></ngt-mesh>
 </ngts-detailed>
+```
+
+## NgtsLOD
+
+Implements Level of Detail (LOD) rendering. Automatically switches between different detail levels of child objects based on camera distance.
+
+Unlike `NgtsDetailed`, this is an implementation based on Angular and angular-three APIs rather than Three's LOD class.
+The component adds and remove objects from the scene graph rather than hiding them with `visible = false`.
+This solves a number of issues such as avoid raycasting over hidden objects.
+
+Usage:
+
+```html
+<ngt-group lod>
+  <ngt-mesh *lodLevel="{distance: 0}" />
+  <ngt-mesh *lodLevel="{distance: 100}" />
+  <ngt-mesh *lodLevel="{distance: 1000}" />
+</ngt-group>
+```
+
+The `[lodLevel]` directive (`NgtsLODLevel`) supports the following options:
+
+| Property     | Description                                       | Default Value |
+| ------------ | ------------------------------------------------- | ------------- |
+| `distance`   | Threshold above which to display the object       | `0`           |
+| `hysteresis` | Prevents rapid switching near distance thresholds | `0`           |
+
+This directive may also be used with the following syntax:
+
+```html
+<ngt-group lod>
+  <ng-template [lodLevel]="{distance: 0}">
+    <ngt-mesh />
+    <ngt-mesh />
+  </ng-template>
+</ngt-group>
 ```
 
 ## NgtsInstances

--- a/libs/soba/performances/README.md
+++ b/libs/soba/performances/README.md
@@ -106,31 +106,35 @@ This solves a number of issues such as avoid raycasting over hidden objects.
 Usage:
 
 ```html
-<ngt-group lod>
-  <ngt-mesh *lodLevel="0" />
-  <ngt-mesh *lodLevel="100" [hysteresis]="0.1" />
-  <ngt-mesh *lodLevel="1000" />
+<ngt-group lod [maxDistance]="10000">
+  <ngt-mesh *lodLevel />
+  <ngt-mesh *lodLevel="{distance: 100, hysteresis: 0.1}" />
+  <ngt-mesh *lodLevel="{distance: 1000}" />
 </ngt-group>
 ```
 
 The `[lod]` directive (`NgtsLODImpl`) supports the following optional input:
 
-| Property      | Description                                                                   | Default Value |
-| ------------- | ----------------------------------------------------------------------------- | ------------- |
-| `maxDistance` | Distance above which nothing is displayed (equivalent to a last empty level)  | `undefined`   |
+| Property      | Description                                                                    | Default Value |
+| ------------- | ------------------------------------------------------------------------------ | ------------- |
+| `maxDistance` | Distance beyond which nothing is displayed (equivalent to a last empty level)  | `undefined`   |
 
-The `[lodLevel]` directive (`NgtsLODLevel`) supports the following inputs:
+The `[lodLevel]` directive (`NgtsLODLevel`) supports the following object inputs:
 
 | Property     | Description                                           | Default Value |
 | ------------ | ----------------------------------------------------- | ------------- |
-| `lodLevel`   | Distance threshold above which to display the object  | `0`           |
+| `distance`   | Distance threshold above which to display the object  | `0`           |
 | `hysteresis` | Prevents rapid switching near distance thresholds     | `0`           |
 
-This directive may also be used with the following syntax:
+This directive may also be used with the following shorthand syntax:
 
 ```html
 <ngt-group lod>
-  <ng-template [lodLevel]="0">
+  <ng-template lodLevel>
+    <ngt-mesh />
+    <ngt-mesh />
+  </ng-template>
+  <ng-template [lodLevel]="{distance: 100}">
     <ngt-mesh />
     <ngt-mesh />
   </ng-template>

--- a/libs/soba/performances/README.md
+++ b/libs/soba/performances/README.md
@@ -107,24 +107,30 @@ Usage:
 
 ```html
 <ngt-group lod>
-  <ngt-mesh *lodLevel="{distance: 0}" />
-  <ngt-mesh *lodLevel="{distance: 100}" />
-  <ngt-mesh *lodLevel="{distance: 1000}" />
+  <ngt-mesh *lodLevel="0" />
+  <ngt-mesh *lodLevel="100" [hysteresis]="0.1" />
+  <ngt-mesh *lodLevel="1000" />
 </ngt-group>
 ```
 
-The `[lodLevel]` directive (`NgtsLODLevel`) supports the following options:
+The `[lod]` directive (`NgtsLODImpl`) supports the following optional input:
 
-| Property     | Description                                       | Default Value |
-| ------------ | ------------------------------------------------- | ------------- |
-| `distance`   | Threshold above which to display the object       | `0`           |
-| `hysteresis` | Prevents rapid switching near distance thresholds | `0`           |
+| Property      | Description                                                                   | Default Value |
+| ------------- | ----------------------------------------------------------------------------- | ------------- |
+| `maxDistance` | Distance above which nothing is displayed (equivalent to a last empty level)  | `undefined`   |
+
+The `[lodLevel]` directive (`NgtsLODLevel`) supports the following inputs:
+
+| Property     | Description                                           | Default Value |
+| ------------ | ----------------------------------------------------- | ------------- |
+| `lodLevel`   | Distance threshold above which to display the object  | `0`           |
+| `hysteresis` | Prevents rapid switching near distance thresholds     | `0`           |
 
 This directive may also be used with the following syntax:
 
 ```html
 <ngt-group lod>
-  <ng-template [lodLevel]="{distance: 0}">
+  <ng-template [lodLevel]="0">
     <ngt-mesh />
     <ngt-mesh />
   </ng-template>

--- a/libs/soba/performances/src/index.ts
+++ b/libs/soba/performances/src/index.ts
@@ -2,6 +2,7 @@ export * from './lib/adaptive-dpr';
 export * from './lib/adaptive-events';
 export * from './lib/bvh';
 export * from './lib/detailed';
+export * from './lib/lod';
 export * from './lib/instances/instances';
 export * from './lib/points/points';
 export * from './lib/segments/segments';

--- a/libs/soba/performances/src/lib/lod.ts
+++ b/libs/soba/performances/src/lib/lod.ts
@@ -1,0 +1,101 @@
+import { Component, contentChildren, CUSTOM_ELEMENTS_SCHEMA, Directive, ElementRef, inject, input, linkedSignal, signal, TemplateRef, viewChild } from "@angular/core";
+import { NgTemplateOutlet } from "@angular/common";
+import { beforeRender, injectStore } from "angular-three";
+import { Object3D, Vector3 } from "three";
+
+const _v1 = new Vector3();
+const _v2 = new Vector3();
+
+/**
+ * Angular-native port of THREE.LOD
+ *
+ * Allows to display an object with several levels of details.
+ *
+ * The main difference with THREE.LOD is that we use angular-three
+ * to add/remove the right object from the scene graph, rather than
+ * setting the visible flag on one of the object, but keeping them
+ * all in the graph.
+ *
+ * Usage:
+ *
+ * ```html
+ * <ngt-group lod>
+ *   <ngt-mesh *lodLevel="{distance: 0}" />
+ *   <ngt-mesh *lodLevel="{distance: 100}" />
+ *   <ngt-mesh *lodLevel="{distance: 1000}" />
+ * </ngt-group>
+ * ```
+ */
+@Component({
+  selector: '[lod]',
+  template: `
+    <ng-container *ngTemplateOutlet="level()?.template" />
+  `,
+	schemas: [CUSTOM_ELEMENTS_SCHEMA],
+ imports: [NgTemplateOutlet],
+})
+export class NgtsLODImpl {
+  private store = injectStore();
+	private container = inject(ElementRef);
+
+  readonly levels = contentChildren(NgtsLODLevel);
+  readonly level = signal<NgtsLODLevel|undefined>(undefined);
+
+  constructor() {
+    beforeRender(() => {
+
+      const levels = this.levels();
+      const currentLevel = this.level();
+
+      let level = levels[0];
+
+      if(levels.length > 1) {
+
+        const container = this.container.nativeElement as Object3D;
+        const {matrixWorld, zoom} = this.store.snapshot.camera;
+
+        _v1.setFromMatrixPosition( matrixWorld );
+        _v2.setFromMatrixPosition( container.matrixWorld );
+
+        const distance = _v1.distanceTo( _v2 ) / zoom;
+
+        for (let i = 1, l = levels.length; i < l; i ++ ) {
+          const _level = levels[i];
+          let options = _level.lodLevel();
+          let levelDistance = options?.distance || 0;
+          let hysteresis = options?.hysteresis || 0;
+
+          if (currentLevel === _level) {
+            levelDistance -= levelDistance * hysteresis;
+          }
+
+          if (distance >= levelDistance) {
+            level = _level;
+          }
+          else {
+            break;
+          }
+        }
+      }
+
+      if(level !== currentLevel) {
+        this.level.set(level);
+      }
+    });
+  }
+}
+
+
+/**
+ * Helper directive to capture a template to attach to
+ * an NgtsLOD component.
+ */
+@Directive({
+  selector: 'ng-template[lodLevel]'
+})
+export class NgtsLODLevel {
+  lodLevel = input<{ distance?: number, hysteresis?: number }>();
+  template = inject(TemplateRef);
+}
+
+export const NgtsLOD = [NgtsLODImpl, NgtsLODLevel] as const;

--- a/libs/soba/performances/src/lib/lod.ts
+++ b/libs/soba/performances/src/lib/lod.ts
@@ -18,6 +18,18 @@ const _v1 = new Vector3();
 const _v2 = new Vector3();
 
 /**
+ * Helper directive to capture a template to attach to
+ * an NgtsLOD component.
+ */
+@Directive({
+  selector: 'ng-template[lodLevel]'
+})
+export class NgtsLODLevel {
+  lodLevel = input(defaultLodLevelOptions, { transform: mergeInputs(defaultLodLevelOptions) });
+  template = inject(TemplateRef);
+}
+
+/**
  * Angular-native port of THREE.LOD
  *
  * Allows to display an object with several levels of details.
@@ -99,19 +111,6 @@ export class NgtsLODImpl {
       }
     });
   }
-}
-
-
-/**
- * Helper directive to capture a template to attach to
- * an NgtsLOD component.
- */
-@Directive({
-  selector: 'ng-template[lodLevel]'
-})
-export class NgtsLODLevel {
-  lodLevel = input(defaultLodLevelOptions, { transform: mergeInputs(defaultLodLevelOptions) });
-  template = inject(TemplateRef);
 }
 
 export const NgtsLOD = [NgtsLODImpl, NgtsLODLevel] as const;

--- a/libs/soba/performances/src/lib/lod.ts
+++ b/libs/soba/performances/src/lib/lod.ts
@@ -31,7 +31,6 @@ const _v2 = new Vector3();
   template: `
     <ng-container [ngTemplateOutlet]="level()?.template" />
   `,
-  schemas: [CUSTOM_ELEMENTS_SCHEMA],
   imports: [NgTemplateOutlet],
 })
 export class NgtsLODImpl {

--- a/libs/soba/performances/src/lib/lod.ts
+++ b/libs/soba/performances/src/lib/lod.ts
@@ -1,7 +1,18 @@
-import { Component, contentChildren, CUSTOM_ELEMENTS_SCHEMA, Directive, ElementRef, inject, input, linkedSignal, signal, TemplateRef, viewChild } from "@angular/core";
+import { Component, contentChildren, Directive, ElementRef, inject, input, signal, TemplateRef } from "@angular/core";
 import { NgTemplateOutlet } from "@angular/common";
 import { beforeRender, injectStore } from "angular-three";
+import { mergeInputs } from 'ngxtension/inject-inputs';
 import { Object3D, Vector3 } from "three";
+
+export type NgtsLODLevelOptions = {
+  distance: number;
+  hysteresis: number;
+}
+
+const defaultLodLevelOptions: NgtsLODLevelOptions = {
+  distance: 0,
+  hysteresis: 0,
+};
 
 const _v1 = new Vector3();
 const _v2 = new Vector3();
@@ -19,10 +30,10 @@ const _v2 = new Vector3();
  * Usage:
  *
  * ```html
- * <ngt-group lod>
- *   <ngt-mesh *lodLevel="0" />
- *   <ngt-mesh *lodLevel="100" [hysteresis]="0.1" />
- *   <ngt-mesh *lodLevel="1000" />
+ * <ngt-group lod [maxDistance]="10000">
+ *   <ngt-mesh *lodLevel />
+ *   <ngt-mesh *lodLevel="{distance: 100, hysteresis: 0.1}" />
+ *   <ngt-mesh *lodLevel="{distance: 1000}" />
  * </ngt-group>
  * ```
  */
@@ -37,7 +48,7 @@ export class NgtsLODImpl {
   maxDistance = input<number>();
 
   private store = injectStore();
-  private container = inject(ElementRef);
+	private container = inject(ElementRef);
 
   readonly levels = contentChildren(NgtsLODLevel);
   readonly level = signal<NgtsLODLevel|undefined>(undefined);
@@ -67,8 +78,7 @@ export class NgtsLODImpl {
         else {
           for (let i = 1, l = levels.length; i < l; i ++ ) {
             const _level = levels[i];
-            let levelDistance = _level.lodLevel();
-            let hysteresis = _level.hysteresis();
+            let {distance: levelDistance, hysteresis} = _level.lodLevel();
 
             if (hysteresis && currentLevel === _level) {
               levelDistance -= levelDistance * hysteresis;
@@ -100,8 +110,7 @@ export class NgtsLODImpl {
   selector: 'ng-template[lodLevel]'
 })
 export class NgtsLODLevel {
-  lodLevel = input<number>(0);
-  hysteresis = input<number>(0);
+  lodLevel = input(defaultLodLevelOptions, { transform: mergeInputs(defaultLodLevelOptions) });
   template = inject(TemplateRef);
 }
 

--- a/libs/soba/performances/src/lib/lod.ts
+++ b/libs/soba/performances/src/lib/lod.ts
@@ -20,23 +20,25 @@ const _v2 = new Vector3();
  *
  * ```html
  * <ngt-group lod>
- *   <ngt-mesh *lodLevel="{distance: 0}" />
- *   <ngt-mesh *lodLevel="{distance: 100}" />
- *   <ngt-mesh *lodLevel="{distance: 1000}" />
+ *   <ngt-mesh *lodLevel="0" />
+ *   <ngt-mesh *lodLevel="100" [hysteresis]="0.1" />
+ *   <ngt-mesh *lodLevel="1000" />
  * </ngt-group>
  * ```
  */
 @Component({
   selector: '[lod]',
   template: `
-    <ng-container *ngTemplateOutlet="level()?.template" />
+    <ng-container [ngTemplateOutlet]="level()?.template" />
   `,
-	schemas: [CUSTOM_ELEMENTS_SCHEMA],
- imports: [NgTemplateOutlet],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  imports: [NgTemplateOutlet],
 })
 export class NgtsLODImpl {
+  maxDistance = input<number>();
+
   private store = injectStore();
-	private container = inject(ElementRef);
+  private container = inject(ElementRef);
 
   readonly levels = contentChildren(NgtsLODLevel);
   readonly level = signal<NgtsLODLevel|undefined>(undefined);
@@ -46,10 +48,11 @@ export class NgtsLODImpl {
 
       const levels = this.levels();
       const currentLevel = this.level();
+      const maxDistance = this.maxDistance();
 
-      let level = levels[0];
+      let level: NgtsLODLevel|undefined = levels[0];
 
-      if(levels.length > 1) {
+      if(level && (levels.length > 1 || maxDistance)) {
 
         const container = this.container.nativeElement as Object3D;
         const {matrixWorld, zoom} = this.store.snapshot.camera;
@@ -59,21 +62,25 @@ export class NgtsLODImpl {
 
         const distance = _v1.distanceTo( _v2 ) / zoom;
 
-        for (let i = 1, l = levels.length; i < l; i ++ ) {
-          const _level = levels[i];
-          let options = _level.lodLevel();
-          let levelDistance = options?.distance || 0;
-          let hysteresis = options?.hysteresis || 0;
+        if(maxDistance && distance > maxDistance) {
+          level = undefined;
+        }
+        else {
+          for (let i = 1, l = levels.length; i < l; i ++ ) {
+            const _level = levels[i];
+            let levelDistance = _level.lodLevel();
+            let hysteresis = _level.hysteresis();
 
-          if (currentLevel === _level) {
-            levelDistance -= levelDistance * hysteresis;
-          }
+            if (hysteresis && currentLevel === _level) {
+              levelDistance -= levelDistance * hysteresis;
+            }
 
-          if (distance >= levelDistance) {
-            level = _level;
-          }
-          else {
-            break;
+            if (distance >= levelDistance) {
+              level = _level;
+            }
+            else {
+              break;
+            }
           }
         }
       }
@@ -94,7 +101,8 @@ export class NgtsLODImpl {
   selector: 'ng-template[lodLevel]'
 })
 export class NgtsLODLevel {
-  lodLevel = input<{ distance?: number, hysteresis?: number }>();
+  lodLevel = input<number>(0);
+  hysteresis = input<number>(0);
   template = inject(TemplateRef);
 }
 

--- a/libs/soba/src/performances/lod.stories.ts
+++ b/libs/soba/src/performances/lod.stories.ts
@@ -1,0 +1,43 @@
+import { ChangeDetectionStrategy, Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { Meta } from '@storybook/angular';
+import { NgtArgs } from 'angular-three';
+import { NgtsOrbitControls } from 'angular-three-soba/controls';
+import { NgtsLOD } from 'angular-three-soba/performances';
+import { storyDecorators, storyFunction } from '../setup-canvas';
+
+@Component({
+	template: `
+		<ngt-group lod>
+			<ngt-mesh *lodLevel="{}">
+				<ngt-icosahedron-geometry *args="[10, 3]" />
+				<ngt-mesh-basic-material color="hotpink" wireframe />
+			</ngt-mesh>
+
+			<ngt-mesh *lodLevel="{distance: 50}">
+				<ngt-icosahedron-geometry *args="[10, 2]" />
+				<ngt-mesh-basic-material color="lightgreen" wireframe />
+			</ngt-mesh>
+
+			<ngt-mesh *lodLevel="{distance: 150, hysteresis: 0.1}">
+				<ngt-icosahedron-geometry *args="[10, 1]" />
+				<ngt-mesh-basic-material color="lightblue" wireframe />
+			</ngt-mesh>
+		</ngt-group>
+
+		<ngts-orbit-controls [options]="{ enablePan: false, enableRotate: false, zoomSpeed: 0.5 }" />
+	`,
+	schemas: [CUSTOM_ELEMENTS_SCHEMA],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	imports: [NgtsLOD, NgtArgs, NgtsOrbitControls],
+})
+class DefaultLODStory {}
+
+export default {
+	title: 'Performances/LOD',
+	decorators: storyDecorators(),
+} as Meta;
+
+export const Default = storyFunction(DefaultLODStory, {
+	camera: { position: [0, 0, 100] },
+	controls: false,
+});

--- a/libs/soba/src/performances/lod.stories.ts
+++ b/libs/soba/src/performances/lod.stories.ts
@@ -7,18 +7,18 @@ import { storyDecorators, storyFunction } from '../setup-canvas';
 
 @Component({
 	template: `
-		<ngt-group lod>
-			<ngt-mesh *lodLevel="{}">
+		<ngt-group lod [maxDistance]="200">
+			<ngt-mesh *lodLevel="0">
 				<ngt-icosahedron-geometry *args="[10, 3]" />
 				<ngt-mesh-basic-material color="hotpink" wireframe />
 			</ngt-mesh>
 
-			<ngt-mesh *lodLevel="{distance: 50}">
+			<ngt-mesh *lodLevel="50" (click)="toggleColor()">
 				<ngt-icosahedron-geometry *args="[10, 2]" />
-				<ngt-mesh-basic-material color="lightgreen" wireframe />
+				<ngt-mesh-basic-material [color]="color()" wireframe />
 			</ngt-mesh>
 
-			<ngt-mesh *lodLevel="{distance: 150, hysteresis: 0.1}">
+			<ngt-mesh *lodLevel="150" [hysteresis]="0.1">
 				<ngt-icosahedron-geometry *args="[10, 1]" />
 				<ngt-mesh-basic-material color="lightblue" wireframe />
 			</ngt-mesh>
@@ -30,7 +30,13 @@ import { storyDecorators, storyFunction } from '../setup-canvas';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	imports: [NgtsLODImpl, NgtsLODLevel, NgtArgs, NgtsOrbitControls],
 })
-class DefaultLODStory {}
+class DefaultLODStory {
+	protected color = signal('#ff0000');
+    
+    toggleColor() {
+        this.color.update(c => c === '#ff0000'? '#00ff00' : '#ff0000' );
+    }
+}
 
 export default {
 	title: 'Performances/LOD',

--- a/libs/soba/src/performances/lod.stories.ts
+++ b/libs/soba/src/performances/lod.stories.ts
@@ -8,17 +8,17 @@ import { storyDecorators, storyFunction } from '../setup-canvas';
 @Component({
 	template: `
 		<ngt-group lod [maxDistance]="200">
-			<ngt-mesh *lodLevel="0">
+			<ngt-mesh *lodLevel>
 				<ngt-icosahedron-geometry *args="[10, 3]" />
 				<ngt-mesh-basic-material color="hotpink" wireframe />
 			</ngt-mesh>
 
-			<ngt-mesh *lodLevel="50" (click)="toggleColor()">
+			<ngt-mesh *lodLevel="{distance: 50}" (click)="toggleColor()">
 				<ngt-icosahedron-geometry *args="[10, 2]" />
 				<ngt-mesh-basic-material [color]="color()" wireframe />
 			</ngt-mesh>
 
-			<ngt-mesh *lodLevel="150" [hysteresis]="0.1">
+			<ngt-mesh *lodLevel="{distance: 150, hysteresis:0.1}">
 				<ngt-icosahedron-geometry *args="[10, 1]" />
 				<ngt-mesh-basic-material color="lightblue" wireframe />
 			</ngt-mesh>

--- a/libs/soba/src/performances/lod.stories.ts
+++ b/libs/soba/src/performances/lod.stories.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, CUSTOM_ELEMENTS_SCHEMA } from '@ang
 import { Meta } from '@storybook/angular';
 import { NgtArgs } from 'angular-three';
 import { NgtsOrbitControls } from 'angular-three-soba/controls';
-import { NgtsLOD } from 'angular-three-soba/performances';
+import { NgtsLODImpl, NgtsLODLevel } from 'angular-three-soba/performances';
 import { storyDecorators, storyFunction } from '../setup-canvas';
 
 @Component({
@@ -28,7 +28,7 @@ import { storyDecorators, storyFunction } from '../setup-canvas';
 	`,
 	schemas: [CUSTOM_ELEMENTS_SCHEMA],
 	changeDetection: ChangeDetectionStrategy.OnPush,
-	imports: [NgtsLOD, NgtArgs, NgtsOrbitControls],
+	imports: [NgtsLODImpl, NgtsLODLevel, NgtArgs, NgtsOrbitControls],
 })
 class DefaultLODStory {}
 

--- a/libs/soba/src/performances/lod.stories.ts
+++ b/libs/soba/src/performances/lod.stories.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ChangeDetectionStrategy, Component, CUSTOM_ELEMENTS_SCHEMA, signal } from '@angular/core';
 import { Meta } from '@storybook/angular';
 import { NgtArgs } from 'angular-three';
 import { NgtsOrbitControls } from 'angular-three-soba/controls';


### PR DESCRIPTION
Implements Level of Detail (LOD) rendering. Automatically switches between different detail levels of child objects based on camera distance.

Unlike `NgtsDetailed`, this is an implementation based on Angular and angular-three APIs rather than Three's LOD class.
The component adds and remove objects from the scene graph rather than hiding them with `visible = false`.
This solves a number of issues such as avoid raycasting over hidden objects.

Usage:

```html
<ngt-group lod>
  <ngt-mesh *lodLevel="{distance: 0}" />
  <ngt-mesh *lodLevel="{distance: 100}" />
  <ngt-mesh *lodLevel="{distance: 1000}" />
</ngt-group>
```

The `[lodLevel]` directive (`NgtsLODLevel`) supports the following options:

| Property     | Description                                       | Default Value |
| ------------ | ------------------------------------------------- | ------------- |
| `distance`   | Threshold above which to display the object       | `0`           |
| `hysteresis` | Prevents rapid switching near distance thresholds | `0`           |

This directive may also be used with the following syntax:

```html
<ngt-group lod>
  <ng-template [lodLevel]="{distance: 0}">
    <ngt-mesh />
    <ngt-mesh />
  </ng-template>
</ngt-group>
```