### PR TITLE
fix(core): use crypto.getRandomValues fallback for __ngt_id__ in non-…

### DIFF
--- a/libs/core/src/lib/instance.spec.ts
+++ b/libs/core/src/lib/instance.spec.ts
@@ -1,0 +1,65 @@
+import { uuidv4Fallback, prepare, getInstanceState } from './instance';
+
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('uuidv4Fallback', () => {
+	it('should return a valid RFC 4122 v4 UUID', () => {
+		const id = uuidv4Fallback();
+		expect(id).toMatch(UUID_V4_REGEX);
+	});
+
+	it('should return unique values on each call', () => {
+		const ids = new Set(Array.from({ length: 100 }, () => uuidv4Fallback()));
+		expect(ids.size).toBe(100);
+	});
+});
+
+describe('prepare', () => {
+	beforeEach(() => {
+		if (typeof crypto.randomUUID !== 'function') {
+			(crypto as any).randomUUID = () => '00000000-0000-4000-8000-000000000000';
+		}
+	});
+
+	it('should set __ngt_id__ to a valid UUID', () => {
+		const obj = {};
+		prepare(obj, 'ngt-test');
+		expect((obj as any).__ngt_id__).toMatch(UUID_V4_REGEX);
+	});
+
+	it('should fall back to uuidv4Fallback when crypto.randomUUID is undefined', () => {
+		const original = (crypto as any).randomUUID;
+		delete (crypto as any).randomUUID;
+
+		const obj = {};
+		prepare(obj, 'ngt-test');
+		expect((obj as any).__ngt_id__).toMatch(UUID_V4_REGEX);
+
+		(crypto as any).randomUUID = original;
+	});
+
+	it('should return the instance state with correct type', () => {
+		const obj = {};
+		const prepared = prepare(obj, 'ngt-mesh');
+		const state = getInstanceState(prepared);
+		expect(state?.type).toBe('ngt-mesh');
+	});
+
+	it('should not reassign __ngt_id__ for already prepared non-primitive objects', () => {
+		const obj = {};
+		prepare(obj, 'ngt-first');
+		const firstId = (obj as any).__ngt_id__;
+
+		prepare(obj, 'ngt-second');
+		expect((obj as any).__ngt_id__).toBe(firstId);
+	});
+
+	it('should reassign __ngt_id__ for ngt-primitive objects', () => {
+		const obj = {};
+		prepare(obj, 'ngt-primitive', { type: 'ngt-primitive' });
+		const firstId = (obj as any).__ngt_id__;
+
+		prepare(obj, 'ngt-primitive', { type: 'ngt-primitive' });
+		expect((obj as any).__ngt_id__).not.toBe(firstId);
+	});
+});

--- a/libs/core/src/lib/instance.ts
+++ b/libs/core/src/lib/instance.ts
@@ -11,6 +11,16 @@ import type {
 import { SignalState, signalState } from './utils/signal-state';
 import { checkUpdate } from './utils/update';
 
+/** RFC 4122 v4 UUID — safe in non-secure contexts (e.g. http:// on LAN). */
+export function uuidv4Fallback(): string {
+	const bytes = new Uint8Array(16);
+	crypto.getRandomValues(bytes);
+	bytes[6] = (bytes[6] & 0x0f) | 0x40;
+	bytes[8] = (bytes[8] & 0x3f) | 0x80;
+	const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0'));
+	return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10).join('')}`;
+}
+
 /**
  * @deprecated Use `getInstanceState` instead. Will be removed in 5.0.0
  * @param obj - The object to get local state from
@@ -126,7 +136,8 @@ export function prepare<TInstance extends NgtAnyRecord = NgtAnyRecord>(
 			return _nonObjects;
 		});
 
-		instance.__ngt_id__ = crypto.randomUUID();
+		instance.__ngt_id__ =
+			typeof crypto.randomUUID === 'function' ? crypto.randomUUID() : uuidv4Fallback();
 		instance.__ngt__ = {
 			previousAttach: null,
 			type,


### PR DESCRIPTION
## Description

When building and deploying an angular-three app to an on-premises environment served over plain HTTP (e.g. `http://192.168.1.x:port`), the 3D scene silently fails to render.

`crypto.randomUUID()` is only available in **secure contexts** (HTTPS or `localhost`). On any plain `http://` origin — including LAN IPs — the function is `undefined`, causing a silent `TypeError` inside the effect created by `afterNextRender`. Because the crash is swallowed by angular-three's zone-external rendering loop, no error appears in console and the scene never initializes.

## Fix

`crypto.getRandomValues()` is available in **all contexts** and can generate a valid RFC 4122 v4 UUID. Fall back to it when `crypto.randomUUID` is absent.

```typescript
// libs/core/src/lib/instance.ts

/** RFC 4122 v4 UUID — safe in non-secure contexts (e.g. http:// on LAN). */
export function uuidv4Fallback(): string {
  const bytes = new Uint8Array(16);
  crypto.getRandomValues(bytes);
  bytes[6] = (bytes[6] & 0x0f) | 0x40;
  bytes[8] = (bytes[8] & 0x3f) | 0x80;
  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0'));
  return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10).join('')}`;
}

// In prepare():
instance.__ngt_id__ =
  typeof crypto.randomUUID === 'function' ? crypto.randomUUID() : uuidv4Fallback();
```

## How to reproduce

1. Build the app and serve it on a non-localhost HTTP address (LAN IP)
2. Open the page — 3D scene is blank, no console errors

Works fine on `http://localhost:4200`, fails on `http://192.168.1.100:4200`.