### PR TITLE
feat(soba): add keyboard controls

### DIFF
--- a/apps/examples/src/app/soba/keyboard-controls/keyboard-controls.ts
+++ b/apps/examples/src/app/soba/keyboard-controls/keyboard-controls.ts
@@ -1,0 +1,18 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { NgtCanvas } from 'angular-three/dom';
+import { SceneGraph } from './scene';
+
+@Component({
+	template: `
+		<ngt-canvas [camera]="{ position: [0, 10, 15], fov: 50 }" shadows>
+			<app-keyboard-controls-scene-graph *canvasContent />
+		</ngt-canvas>
+		<div class="absolute bottom-4 left-1/2 -translate-x-1/2 rounded bg-black/60 px-3 py-1 text-sm text-white">
+			WASD / arrow keys to move &middot; Space to change color
+		</div>
+	`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	imports: [NgtCanvas, SceneGraph],
+	host: { class: 'keyboard-controls-soba' },
+})
+export default class KeyboardControls {}

--- a/apps/examples/src/app/soba/keyboard-controls/scene.ts
+++ b/apps/examples/src/app/soba/keyboard-controls/scene.ts
@@ -1,0 +1,98 @@
+import {
+	ChangeDetectionStrategy,
+	Component,
+	computed,
+	CUSTOM_ELEMENTS_SCHEMA,
+	ElementRef,
+	inject,
+	viewChild,
+} from '@angular/core';
+import { beforeRender, NgtArgs } from 'angular-three';
+import { createKeyboardControls, NgtsKeyboardControls } from 'angular-three-soba/controls';
+import { Mesh, Vector3 } from 'three';
+
+const { controlsMap, injectKeyboardControls } = createKeyboardControls([
+	{ name: 'forward', keys: ['ArrowUp', 'KeyW'] },
+	{ name: 'back', keys: ['ArrowDown', 'KeyS'] },
+	{ name: 'left', keys: ['ArrowLeft', 'KeyA'] },
+	{ name: 'right', keys: ['ArrowRight', 'KeyD'] },
+	{ name: 'color', keys: ['Space'], toggle: true },
+]);
+
+@Component({
+	selector: 'app-keyboard-player',
+	template: `
+		<ngt-mesh #mesh castShadow [position]="[0, 0.5, 0]">
+			<ngt-cone-geometry *args="[1, 3, 4]" />
+			<ngt-mesh-lambert-material [color]="color()" />
+		</ngt-mesh>
+
+		<ngt-mesh [position]="[0, -1.45, 0]" [rotation]="[-Math.PI / 2, 0, 0]">
+			<ngt-ring-geometry *args="[2.25, 2.5, 32]" />
+			<ngt-mesh-basic-material [color]="moving() ? '#f7d060' : '#2f2f37'" />
+		</ngt-mesh>
+	`,
+	imports: [NgtArgs],
+	schemas: [CUSTOM_ELEMENTS_SCHEMA],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class Player {
+	protected readonly Math = Math;
+
+	private keyboardControls = injectKeyboardControls();
+
+	// reactive form + toggle action: Space flips the 'color' state on each press
+	protected color = computed(() => (this.keyboardControls.select('color')() ? 'red' : 'green'));
+
+	// reactive form: memoized per-action signals composed into a derived signal
+	protected moving = computed(
+		() =>
+			this.keyboardControls.select('forward')() ||
+			this.keyboardControls.select('back')() ||
+			this.keyboardControls.select('left')() ||
+			this.keyboardControls.select('right')(),
+	);
+
+	private meshRef = viewChild.required<ElementRef<Mesh>>('mesh');
+
+	constructor() {
+		// transient form: poll the non-reactive snapshot every frame for continuous movement
+		const velocity = new Vector3();
+		beforeRender(({ delta }) => {
+			const mesh = this.meshRef().nativeElement;
+			const { forward, back, left, right } = this.keyboardControls.snapshot;
+
+			velocity.x = Number(right) - Number(left);
+			velocity.z = Number(back) - Number(forward);
+
+			mesh.position.addScaledVector(velocity, 10 * delta);
+			mesh.rotateY(4 * delta * velocity.x);
+		});
+	}
+}
+
+@Component({
+	selector: 'app-keyboard-controls-scene-graph',
+	template: `
+		<ngt-color attach="background" *args="['#171720']" />
+
+		<ngt-ambient-light [intensity]="0.5" />
+		<ngt-directional-light [position]="[5, 10, 5]" [intensity]="Math.PI" castShadow />
+
+		<app-keyboard-player />
+
+		<ngt-grid-helper *args="[100, 100, '#4f4f4f', '#2f2f37']" [position]="[0, -1.5, 0]" />
+	`,
+	hostDirectives: [NgtsKeyboardControls],
+	imports: [NgtArgs, Player],
+	schemas: [CUSTOM_ELEMENTS_SCHEMA],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SceneGraph {
+	protected readonly Math = Math;
+
+	constructor() {
+		// hostDirective form: provide + configure NgtsKeyboardControls without a template binding
+		inject(NgtsKeyboardControls).map.set(controlsMap);
+	}
+}

--- a/apps/examples/src/app/soba/soba.routes.ts
+++ b/apps/examples/src/app/soba/soba.routes.ts
@@ -268,6 +268,17 @@ const routes: Routes = [
 		},
 	},
 	{
+		path: 'keyboard-controls',
+		loadComponent: () => import('./keyboard-controls/keyboard-controls'),
+		data: {
+			credits: {
+				title: 'Keyboard Controls',
+				link: 'https://drei.docs.pmnd.rs/controls/keyboard-controls',
+				class: 'text-white',
+			},
+		},
+	},
+	{
 		path: '',
 		redirectTo: 'stars',
 		pathMatch: 'full',

--- a/libs/soba/controls/README.md
+++ b/libs/soba/controls/README.md
@@ -16,6 +16,7 @@ npm install camera-controls maath
 ## TOC
 
 - [NgtsCameraControls](#ngtscameracontrols)
+- [NgtsKeyboardControls](#ngtskeyboardcontrols)
 - [NgtsOrbitControls](#ngtsorbitcontrols)
 - [NgtsPointerLockControls](#ngtspointerLockcontrols)
 - [NgtsScrollControls](#ngtsscrollcontrols)
@@ -67,6 +68,96 @@ class DefaultCameraControlsStory {
 				void controls.rotate(theta, phi, animate);
 			} else {
 				void controls.reset(true);
+			}
+		});
+	}
+}
+```
+
+## NgtsKeyboardControls
+
+A renderless attribute directive that turns a user-defined controls map into keyboard state, ported from `@react-three/drei`'s `KeyboardControls`. It attaches `keydown`/`keyup` listeners to `window` (or a custom `domElement`) and distributes the pressed state of named actions to descendants via dependency injection — what happens when an action is pressed is entirely up to consumers of `injectKeyboardControls`.
+
+Multiple physical keys can map to one action. Held keys are reference-counted per action, so OS auto-repeat and overlapping holds of sibling keys never produce duplicate transitions. Prefer `event.code` values (e.g. `'KeyW'`, `'Space'`) in the map — `event.key` values are layout- and case-sensitive.
+
+### Inputs
+
+| Property         | Description                                                                                                                                          | Default Value |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| keyboardControls | The controls map: an array of `{ name, keys, up? }` entries. A `model()` — hostDirective consumers can `inject(NgtsKeyboardControls).map.set(...)`.  | `[]`          |
+| domElement       | The event source the listeners attach to.                                                                                                            | `window`      |
+| preventDefault   | When `true`, listeners are registered non-passively and `preventDefault()` is called for mapped keys (e.g. to stop `Space` from scrolling the page). | `false`       |
+
+Each entry supports two discrete-action modes on top of the default pressed-while-held behavior:
+
+- `up: false` — fire-on-press: the state latches `true` after the first press and only `keyChange` fires on subsequent press edges. Consume via `keyChange`.
+- `toggle: true` — stateful on/off: each press edge flips the state between `true` and `false`; `keyup` is ignored (takes precedence over `up`). Consume via the reactive `select()` signal.
+
+### Outputs
+
+| Output    | Description                                                                                           |
+| --------- | ----------------------------------------------------------------------------------------------------- |
+| keyChange | Emits `{ name, pressed, state }` on every action transition (and on each press edge for `up: false`). |
+
+### Usage
+
+Define the map once at module level with `createKeyboardControls` — a runtime identity function that infers the action names as literal types, so the returned `injectKeyboardControls` is fully typed without repeating the generic at every call site:
+
+```ts
+export const { controlsMap, injectKeyboardControls } = createKeyboardControls([
+	{ name: 'forward', keys: ['ArrowUp', 'KeyW'] },
+	{ name: 'back', keys: ['ArrowDown', 'KeyS'] },
+	{ name: 'left', keys: ['ArrowLeft', 'KeyA'] },
+	{ name: 'right', keys: ['ArrowRight', 'KeyD'] },
+	{ name: 'jump', keys: ['Space'], up: false },
+]);
+```
+
+Provide it via the template:
+
+```html
+<ngt-group [keyboardControls]="controlsMap">
+	<app-player />
+</ngt-group>
+```
+
+or via `hostDirectives`, setting the map programmatically:
+
+```ts
+@Component({
+	hostDirectives: [NgtsKeyboardControls],
+	/* ... */
+})
+export class SceneGraph {
+	constructor() {
+		inject(NgtsKeyboardControls).map.set(controlsMap);
+	}
+}
+```
+
+Consume it in any descendant:
+
+```ts
+@Component({
+	/* ... */
+})
+export class Player {
+	private keyboardControls = injectKeyboardControls();
+
+	// reactive form: a memoized Signal<boolean> per action
+	protected jumping = this.keyboardControls.select('jump');
+
+	constructor() {
+		// transient form: poll a non-reactive snapshot in the frame loop
+		beforeRender(({ delta }) => {
+			const { forward, back, left, right } = this.keyboardControls.snapshot;
+			// move things
+		});
+
+		// edge events for discrete actions
+		this.keyboardControls.keyChange.subscribe(({ name, pressed }) => {
+			if (name === 'jump' && pressed) {
+				// jump!
 			}
 		});
 	}

--- a/libs/soba/controls/src/index.ts
+++ b/libs/soba/controls/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/camera-controls';
+export * from './lib/keyboard-controls';
 export * from './lib/orbit-controls';
 export * from './lib/pointer-lock-controls';
 export * from './lib/scroll-controls';

--- a/libs/soba/controls/src/lib/keyboard-controls.spec.ts
+++ b/libs/soba/controls/src/lib/keyboard-controls.spec.ts
@@ -1,0 +1,201 @@
+import { Component, viewChild } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+	createKeyboardControls,
+	injectKeyboardControls,
+	NgtsKeyboardControls,
+	NgtsKeyboardControlsChangeEvent,
+	NgtsKeyboardControlsEntry,
+} from './keyboard-controls';
+
+const map: NgtsKeyboardControlsEntry[] = [
+	{ name: 'forward', keys: ['ArrowUp', 'KeyW'] },
+	{ name: 'back', keys: ['ArrowDown', 'KeyS'] },
+	{ name: 'jump', keys: ['Space'], up: false },
+	{ name: 'torch', keys: ['KeyT'], toggle: true },
+];
+
+@Component({
+	template: `
+		<div [keyboardControls]="map" (keyChange)="events.push($event)"></div>
+	`,
+	imports: [NgtsKeyboardControls],
+})
+class Host {
+	map = map;
+	events: NgtsKeyboardControlsChangeEvent[] = [];
+	keyboardControls = viewChild.required(NgtsKeyboardControls);
+}
+
+function dispatch(type: 'keydown' | 'keyup', init: KeyboardEventInit) {
+	window.dispatchEvent(new KeyboardEvent(type, init));
+}
+
+describe(NgtsKeyboardControls.name, () => {
+	function setup() {
+		const fixture = TestBed.createComponent(Host);
+		fixture.detectChanges();
+		const host = fixture.componentInstance;
+		return { fixture, host, keyboardControls: host.keyboardControls() };
+	}
+
+	it('should seed state with every action unpressed', () => {
+		const { keyboardControls } = setup();
+		expect(keyboardControls.state()).toEqual({ forward: false, back: false, jump: false, torch: false });
+	});
+
+	it('should transition on keydown/keyup matched by event.code', () => {
+		const { host, keyboardControls } = setup();
+
+		dispatch('keydown', { code: 'KeyW' });
+		expect(keyboardControls.state()['forward']).toBe(true);
+		expect(host.events).toEqual([
+			{ name: 'forward', pressed: true, state: { forward: true, back: false, jump: false, torch: false } },
+		]);
+
+		dispatch('keyup', { code: 'KeyW' });
+		expect(keyboardControls.state()['forward']).toBe(false);
+		expect(host.events.length).toEqual(2);
+		expect(host.events[1]).toEqual({
+			name: 'forward',
+			pressed: false,
+			state: { forward: false, back: false, jump: false, torch: false },
+		});
+	});
+
+	it('should match event.key as well', () => {
+		const { keyboardControls } = setup();
+
+		dispatch('keydown', { key: 'ArrowUp' });
+		expect(keyboardControls.state()['forward']).toBe(true);
+
+		dispatch('keyup', { key: 'ArrowUp' });
+		expect(keyboardControls.state()['forward']).toBe(false);
+	});
+
+	it('should ignore keys that are not in the map', () => {
+		const { host, keyboardControls } = setup();
+
+		dispatch('keydown', { code: 'KeyX' });
+		expect(keyboardControls.state()).toEqual({ forward: false, back: false, jump: false, torch: false });
+		expect(host.events.length).toEqual(0);
+	});
+
+	it('should reference-count multiple held keys of the same action', () => {
+		const { host, keyboardControls } = setup();
+
+		dispatch('keydown', { code: 'KeyW' });
+		dispatch('keydown', { key: 'ArrowUp' });
+		expect(keyboardControls.state()['forward']).toBe(true);
+		expect(host.events.length).toEqual(1);
+
+		// releasing one key while the sibling key is still held keeps the action pressed
+		dispatch('keyup', { code: 'KeyW' });
+		expect(keyboardControls.state()['forward']).toBe(true);
+		expect(host.events.length).toEqual(1);
+
+		dispatch('keyup', { key: 'ArrowUp' });
+		expect(keyboardControls.state()['forward']).toBe(false);
+		expect(host.events.length).toEqual(2);
+	});
+
+	it('should not re-emit on OS auto-repeat keydown', () => {
+		const { host } = setup();
+
+		dispatch('keydown', { code: 'KeyW' });
+		dispatch('keydown', { code: 'KeyW', repeat: true });
+		dispatch('keydown', { code: 'KeyW', repeat: true });
+		expect(host.events.length).toEqual(1);
+	});
+
+	it('should latch up:false actions true and emit on each press edge', () => {
+		const { host, keyboardControls } = setup();
+
+		dispatch('keydown', { code: 'Space' });
+		expect(keyboardControls.state()['jump']).toBe(true);
+		expect(host.events.length).toEqual(1);
+
+		// keyup does not reset the latched state and emits nothing
+		dispatch('keyup', { code: 'Space' });
+		expect(keyboardControls.state()['jump']).toBe(true);
+		expect(host.events.length).toEqual(1);
+
+		// but the next physical press is a fresh edge
+		dispatch('keydown', { code: 'Space' });
+		expect(host.events.length).toEqual(2);
+		expect(host.events[1].pressed).toBe(true);
+	});
+
+	it('should flip toggle actions on each press edge and ignore keyup', () => {
+		const { host, keyboardControls } = setup();
+
+		dispatch('keydown', { code: 'KeyT' });
+		expect(keyboardControls.state()['torch']).toBe(true);
+		expect(host.events.length).toEqual(1);
+		expect(host.events[0]).toEqual(expect.objectContaining({ name: 'torch', pressed: true }));
+
+		// keyup is a no-op for toggle actions
+		dispatch('keyup', { code: 'KeyT' });
+		expect(keyboardControls.state()['torch']).toBe(true);
+		expect(host.events.length).toEqual(1);
+
+		// next press edge flips it back off
+		dispatch('keydown', { code: 'KeyT' });
+		expect(keyboardControls.state()['torch']).toBe(false);
+		expect(host.events.length).toEqual(2);
+		expect(host.events[1]).toEqual(expect.objectContaining({ name: 'torch', pressed: false }));
+		dispatch('keyup', { code: 'KeyT' });
+
+		dispatch('keydown', { code: 'KeyT' });
+		expect(keyboardControls.state()['torch']).toBe(true);
+	});
+
+	it('should not flip toggle actions on OS auto-repeat keydown', () => {
+		const { host, keyboardControls } = setup();
+
+		dispatch('keydown', { code: 'KeyT' });
+		dispatch('keydown', { code: 'KeyT', repeat: true });
+		dispatch('keydown', { code: 'KeyT', repeat: true });
+		expect(keyboardControls.state()['torch']).toBe(true);
+		expect(host.events.length).toEqual(1);
+	});
+
+	it('should expose a memoized per-action signal via select()', () => {
+		const { keyboardControls } = setup();
+
+		const forward = keyboardControls.select('forward');
+		expect(forward).toBe(keyboardControls.select('forward'));
+		expect(forward()).toBe(false);
+
+		dispatch('keydown', { code: 'KeyW' });
+		expect(forward()).toBe(true);
+	});
+
+	it('should remove listeners on destroy', () => {
+		const { fixture, host } = setup();
+
+		fixture.destroy();
+		dispatch('keydown', { code: 'KeyW' });
+		expect(host.events.length).toEqual(0);
+	});
+
+	describe(injectKeyboardControls.name, () => {
+		it('should throw outside of a keyboardControls context', () => {
+			TestBed.runInInjectionContext(() => {
+				expect(() => injectKeyboardControls()).toThrowError(/keyboardControls directive/);
+			});
+		});
+	});
+
+	describe(createKeyboardControls.name, () => {
+		it('should return the entries as-is with a typed inject function', () => {
+			const entries = [
+				{ name: 'forward', keys: ['KeyW'] },
+				{ name: 'jump', keys: ['Space'], up: false },
+			] as const;
+			const { controlsMap, injectKeyboardControls: injectTyped } = createKeyboardControls(entries);
+			expect(controlsMap).toBe(entries);
+			expect(typeof injectTyped).toBe('function');
+		});
+	});
+});

--- a/libs/soba/controls/src/lib/keyboard-controls.ts
+++ b/libs/soba/controls/src/lib/keyboard-controls.ts
@@ -1,0 +1,284 @@
+import {
+	computed,
+	Directive,
+	DOCUMENT,
+	effect,
+	inject,
+	Injector,
+	input,
+	model,
+	output,
+	Signal,
+	signal,
+	untracked,
+} from '@angular/core';
+import { assertInjector } from 'ngxtension/assert-injector';
+
+/**
+ * A single action entry in the keyboard controls map.
+ */
+export interface NgtsKeyboardControlsEntry<TName extends string = string> {
+	/**
+	 * Name of the action.
+	 */
+	name: TName;
+	/**
+	 * The keys that trigger the action. Matched against either `event.key` or `event.code`.
+	 * Prefer `event.code` values (e.g. `'KeyW'`, `'Space'`) — `event.key` values are
+	 * layout- and case-sensitive (`'w'` vs `'W'` with Shift held).
+	 */
+	keys: string[];
+	/**
+	 * Whether the action also responds to `keyup`. When `false`, the action state latches
+	 * `true` after the first press and only `keyChange` fires on subsequent press edges —
+	 * useful for discrete fire-on-press actions. Ignored when `toggle` is `true`.
+	 * @default true
+	 */
+	up?: boolean;
+	/**
+	 * Whether the action acts as a toggle: each press edge flips the state between
+	 * `true` and `false`; `keyup` is ignored. Takes precedence over `up`.
+	 * @default false
+	 */
+	toggle?: boolean;
+}
+
+/**
+ * The pressed state of every action in the keyboard controls map.
+ */
+export type NgtsKeyboardControlsState<TName extends string = string> = { [K in TName]: boolean };
+
+/**
+ * Payload emitted by the `keyChange` output whenever an action transitions.
+ */
+export interface NgtsKeyboardControlsChangeEvent<TName extends string = string> {
+	/**
+	 * Name of the action that transitioned.
+	 */
+	name: TName;
+	/**
+	 * Whether the action is now pressed.
+	 */
+	pressed: boolean;
+	/**
+	 * A snapshot of the full state after the transition.
+	 */
+	state: NgtsKeyboardControlsState<TName>;
+}
+
+/**
+ * A renderless directive that turns a user-defined controls map into keyboard state.
+ *
+ * NgtsKeyboardControls attaches `keydown`/`keyup` listeners to `window` (or a custom
+ * `domElement`) and distributes the pressed state of named actions to descendants via
+ * dependency injection. It owns no gameplay semantics — what happens when an action is
+ * pressed is entirely up to consumers of `injectKeyboardControls`.
+ *
+ * Multiple physical keys can map to one action; held keys are reference-counted per action,
+ * so OS auto-repeat and overlapping holds of sibling keys never produce duplicate transitions.
+ *
+ * @example
+ * ```html
+ * <ngt-group [keyboardControls]="controlsMap">
+ *   <app-player />
+ * </ngt-group>
+ * ```
+ *
+ * @example
+ * ```ts
+ * // hostDirective form: provide + configure programmatically, no template binding
+ * @Component({
+ *   hostDirectives: [NgtsKeyboardControls],
+ * })
+ * export class SceneGraph {
+ *   constructor() {
+ *     inject(NgtsKeyboardControls).map.set(controlsMap);
+ *   }
+ * }
+ * ```
+ */
+@Directive({ selector: '[keyboardControls]' })
+export class NgtsKeyboardControls<TName extends string = string> {
+	map = model<ReadonlyArray<NgtsKeyboardControlsEntry<TName>>>([], { alias: 'keyboardControls' });
+	/**
+	 * The event source the listeners attach to.
+	 * @default window
+	 */
+	domElement = input<HTMLElement | Document | Window | null>(null);
+	/**
+	 * When `true`, listeners are registered non-passively and `preventDefault()` is called
+	 * for events whose key is in the map (e.g. to stop Space from scrolling the page).
+	 * @default false
+	 */
+	preventDefault = input(false);
+	/**
+	 * Emits on every action transition (and on each press edge for `up: false` actions).
+	 */
+	keyChange = output<NgtsKeyboardControlsChangeEvent<TName>>();
+
+	private document = inject(DOCUMENT);
+	private source = signal<NgtsKeyboardControlsState<TName>>({} as NgtsKeyboardControlsState<TName>);
+	private selectors = new Map<TName, Signal<boolean>>();
+
+	/**
+	 * The pressed state of every action as a readonly signal.
+	 */
+	state = this.source.asReadonly();
+
+	/**
+	 * A non-reactive snapshot of the current state. Use this inside `beforeRender`
+	 * to poll keyboard state every frame without creating signal dependencies.
+	 */
+	get snapshot() {
+		return untracked(this.source);
+	}
+
+	constructor() {
+		effect((onCleanup) => {
+			const map = this.map();
+			if (!map.length) return;
+
+			const target = this.domElement() ?? this.document.defaultView;
+			if (!target) return;
+
+			const preventDefault = this.preventDefault();
+
+			// seed the state with every action unpressed
+			this.source.set(
+				map.reduce((prev, cur) => {
+					prev[cur.name] = false;
+					return prev;
+				}, {} as NgtsKeyboardControlsState<TName>),
+			);
+
+			// each action reference-counts its currently held keys so multiple physical keys
+			// and OS auto-repeat resolve to single pressed/released transitions
+			const actions: Array<Omit<NgtsKeyboardControlsEntry<TName>, 'keys'> & { held: Set<string> }> = [];
+			const keyMap = new Map<string, (typeof actions)[number]>();
+
+			for (const entry of map) {
+				const action: (typeof actions)[number] = {
+					name: entry.name,
+					up: entry.up ?? true,
+					toggle: entry.toggle ?? false,
+					held: new Set(),
+				};
+				actions.push(action);
+				for (const key of entry.keys) {
+					keyMap.set(key, action);
+				}
+			}
+
+			const transition = (action: (typeof actions)[number], pressed: boolean) => {
+				this.source.update((prev) => ({ ...prev, [action.name]: pressed }));
+				this.keyChange.emit({ name: action.name, pressed, state: untracked(this.source) });
+			};
+
+			const resolve = (event: KeyboardEvent) => {
+				const matched = keyMap.has(event.key) ? event.key : event.code;
+				const action = keyMap.get(matched);
+				if (action && preventDefault) event.preventDefault();
+				return [matched, action] as const;
+			};
+
+			const downHandler = (event: KeyboardEvent) => {
+				const [matched, action] = resolve(event);
+				if (!action) return;
+				const wasHeld = action.held.size > 0;
+				action.held.add(matched);
+				if (wasHeld) return;
+				if (action.toggle) transition(action, !untracked(this.source)[action.name]);
+				else transition(action, true);
+			};
+
+			const upHandler = (event: KeyboardEvent) => {
+				const [matched, action] = resolve(event);
+				if (!action) return;
+				action.held.delete(matched);
+				if (action.held.size === 0 && action.up && !action.toggle) transition(action, false);
+			};
+
+			const listenerOptions = { passive: !preventDefault };
+			target.addEventListener('keydown', downHandler as EventListener, listenerOptions);
+			target.addEventListener('keyup', upHandler as EventListener, listenerOptions);
+
+			onCleanup(() => {
+				target.removeEventListener('keydown', downHandler as EventListener);
+				target.removeEventListener('keyup', upHandler as EventListener);
+			});
+		});
+	}
+
+	/**
+	 * Returns a memoized readonly signal for a single action's pressed state.
+	 * The signal only notifies when that action actually transitions.
+	 */
+	select(name: TName): Signal<boolean> {
+		let selector = this.selectors.get(name);
+		if (!selector) {
+			selector = computed(() => this.state()[name] ?? false);
+			this.selectors.set(name, selector);
+		}
+		return selector;
+	}
+}
+
+/**
+ * Injects the nearest NgtsKeyboardControls instance, typed to the given action names.
+ *
+ * @example
+ * ```ts
+ * const keyboardControls = injectKeyboardControls<'forward' | 'back' | 'jump'>();
+ *
+ * // reactive form
+ * forward = keyboardControls.select('forward');
+ *
+ * // transient form, polled in the frame loop
+ * beforeRender(() => {
+ *   const { forward, back } = keyboardControls.snapshot;
+ * });
+ * ```
+ *
+ * @param options - Configuration options
+ * @param options.injector - Optional injector for dependency injection context
+ */
+export function injectKeyboardControls<TName extends string = string>({ injector }: { injector?: Injector } = {}) {
+	return assertInjector(injectKeyboardControls, injector, () => {
+		const keyboardControls = inject(NgtsKeyboardControls, { optional: true });
+		if (!keyboardControls) {
+			throw new Error(
+				'injectKeyboardControls must be used within an element with the keyboardControls directive',
+			);
+		}
+		return keyboardControls as unknown as NgtsKeyboardControls<TName>;
+	});
+}
+
+/**
+ * Creates a typed keyboard controls map outside of the Angular lifecycle.
+ *
+ * A runtime identity function whose value is type-level: the action names are inferred
+ * as literals from the entries, so the returned `injectKeyboardControls` is fully typed
+ * without repeating the generic at every call site.
+ *
+ * @example
+ * ```ts
+ * export const { controlsMap, injectKeyboardControls } = createKeyboardControls([
+ *   { name: 'forward', keys: ['ArrowUp', 'KeyW'] },
+ *   { name: 'back', keys: ['ArrowDown', 'KeyS'] },
+ *   { name: 'jump', keys: ['Space'], up: false },
+ * ]);
+ *
+ * // in a template: <ngt-group [keyboardControls]="controlsMap">
+ * // in a consumer: const keyboardControls = injectKeyboardControls();
+ * ```
+ */
+export function createKeyboardControls<const TEntries extends ReadonlyArray<NgtsKeyboardControlsEntry>>(
+	entries: TEntries,
+) {
+	type TName = TEntries[number]['name'];
+	return {
+		controlsMap: entries as ReadonlyArray<NgtsKeyboardControlsEntry<TName>>,
+		injectKeyboardControls: (options: { injector?: Injector } = {}) => injectKeyboardControls<TName>(options),
+	};
+}

--- a/libs/soba/src/controls/keyboard-controls.stories.ts
+++ b/libs/soba/src/controls/keyboard-controls.stories.ts
@@ -1,0 +1,201 @@
+import {
+	ChangeDetectionStrategy,
+	Component,
+	computed,
+	CUSTOM_ELEMENTS_SCHEMA,
+	DestroyRef,
+	ElementRef,
+	inject,
+	signal,
+	viewChild,
+} from '@angular/core';
+import { Meta } from '@storybook/angular';
+import { beforeRender, NgtArgs } from 'angular-three';
+import { createKeyboardControls, NgtsKeyboardControls } from 'angular-three-soba/controls';
+import { Mesh, Vector3 } from 'three';
+import { storyDecorators, storyFunction } from '../setup-canvas';
+
+/**
+ * Default (up: true) — actions are pressed while their keys are held.
+ * The frame loop polls the non-reactive snapshot for continuous movement.
+ */
+const movement = createKeyboardControls([
+	{ name: 'forward', keys: ['ArrowUp', 'KeyW'] },
+	{ name: 'back', keys: ['ArrowDown', 'KeyS'] },
+	{ name: 'left', keys: ['ArrowLeft', 'KeyA'] },
+	{ name: 'right', keys: ['ArrowRight', 'KeyD'] },
+]);
+
+@Component({
+	selector: 'keyboard-player',
+	template: `
+		<ngt-mesh #mesh>
+			<ngt-cone-geometry *args="[1, 3, 4]" />
+			<ngt-mesh-lambert-material color="green" />
+		</ngt-mesh>
+	`,
+	imports: [NgtArgs],
+	schemas: [CUSTOM_ELEMENTS_SCHEMA],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class Player {
+	private meshRef = viewChild.required<ElementRef<Mesh>>('mesh');
+	private keyboardControls = movement.injectKeyboardControls();
+
+	constructor() {
+		// transient form: poll the non-reactive snapshot every frame for continuous movement
+		const velocity = new Vector3();
+		beforeRender(({ delta }) => {
+			const mesh = this.meshRef().nativeElement;
+			const { forward, back, left, right } = this.keyboardControls.snapshot;
+
+			velocity.x = Number(right) - Number(left);
+			velocity.z = Number(back) - Number(forward);
+
+			mesh.position.addScaledVector(velocity, 10 * delta);
+			mesh.rotateY(4 * delta * velocity.x);
+		});
+	}
+}
+
+@Component({
+	template: `
+		<ngt-group [keyboardControls]="controlsMap">
+			<keyboard-player />
+		</ngt-group>
+
+		<ngt-grid-helper *args="[100, 100]" [position]="[0, -1.5, 0]" />
+	`,
+	imports: [NgtsKeyboardControls, NgtArgs, Player],
+	schemas: [CUSTOM_ELEMENTS_SCHEMA],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class DefaultKeyboardControlsStory {
+	protected controlsMap = movement.controlsMap;
+}
+
+/**
+ * up: false — a discrete fire-on-press action. The state latches true after the
+ * first press and never resets, so the reactive/select form is NOT useful here;
+ * consume the press edges via the keyChange output instead. Holding the key does
+ * not re-fire (auto-repeat is deduplicated).
+ */
+const press = createKeyboardControls([{ name: 'spawn', keys: ['Space'], up: false }]);
+
+@Component({
+	selector: 'press-spawner',
+	template: `
+		@for (box of boxes(); track $index) {
+			<ngt-mesh [position]="[($index % 10) * 1.5 - 6.75, 0, -Math.floor($index / 10) * 1.5]">
+				<ngt-box-geometry />
+				<ngt-mesh-lambert-material color="orange" />
+			</ngt-mesh>
+		}
+
+		<ngt-grid-helper *args="[100, 100]" [position]="[0, -1.5, 0]" />
+	`,
+	imports: [NgtArgs],
+	schemas: [CUSTOM_ELEMENTS_SCHEMA],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class PressSpawner {
+	protected readonly Math = Math;
+
+	private count = signal(0);
+	protected boxes = computed(() => Array.from({ length: this.count() }));
+
+	constructor() {
+		const keyboardControls = press.injectKeyboardControls();
+
+		// each physical press of Space spawns exactly one box — holding the key does nothing more
+		const subscription = keyboardControls.keyChange.subscribe(({ name, pressed }) => {
+			if (name === 'spawn' && pressed) this.count.update((count) => count + 1);
+		});
+		inject(DestroyRef).onDestroy(() => subscription.unsubscribe());
+	}
+}
+
+@Component({
+	template: `
+		<ngt-group [keyboardControls]="controlsMap">
+			<press-spawner />
+		</ngt-group>
+	`,
+	imports: [NgtsKeyboardControls, PressSpawner],
+	schemas: [CUSTOM_ELEMENTS_SCHEMA],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class FireOnPressKeyboardControlsStory {
+	protected controlsMap = press.controlsMap;
+}
+
+/**
+ * toggle: true — each press edge flips the action state between true and false;
+ * keyup is ignored. The reactive select() signal is the natural consumer: bind it
+ * straight into the template.
+ */
+const toggle = createKeyboardControls([{ name: 'color', keys: ['Space'], toggle: true }]);
+
+@Component({
+	selector: 'toggle-cone',
+	template: `
+		<ngt-mesh>
+			<ngt-cone-geometry *args="[1, 3, 4]" />
+			<ngt-mesh-lambert-material [color]="color()" />
+		</ngt-mesh>
+
+		<ngt-grid-helper *args="[100, 100]" [position]="[0, -1.5, 0]" />
+	`,
+	imports: [NgtArgs],
+	schemas: [CUSTOM_ELEMENTS_SCHEMA],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class ToggleCone {
+	// reactive form: select() is a live Signal<boolean> that flips on each press of Space
+	private colorToggled = toggle.injectKeyboardControls().select('color');
+	protected color = computed(() => (this.colorToggled() ? 'red' : 'green'));
+}
+
+@Component({
+	template: `
+		<ngt-group [keyboardControls]="controlsMap">
+			<toggle-cone />
+		</ngt-group>
+	`,
+	imports: [NgtsKeyboardControls, ToggleCone],
+	schemas: [CUSTOM_ELEMENTS_SCHEMA],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class ToggleKeyboardControlsStory {
+	protected controlsMap = toggle.controlsMap;
+}
+
+export default {
+	title: 'Controls/KeyboardControls',
+	decorators: storyDecorators(),
+} as Meta;
+
+/**
+ * Use WASD / arrow keys to move the player. Actions are pressed while held.
+ */
+export const Default = storyFunction(DefaultKeyboardControlsStory, {
+	camera: { position: [0, 10, 15], fov: 50 },
+	controls: null,
+});
+
+/**
+ * `up: false` — each physical press of Space spawns one box via `keyChange` edges;
+ * holding the key does not repeat.
+ */
+export const FireOnPress = storyFunction(FireOnPressKeyboardControlsStory, {
+	camera: { position: [0, 10, 15], fov: 50 },
+	controls: null,
+});
+
+/**
+ * `toggle: true` — press Space to flip the cone color back and forth via `select()`.
+ */
+export const Toggle = storyFunction(ToggleKeyboardControlsStory, {
+	camera: { position: [0, 5, 10], fov: 50 },
+	controls: null,
+});

--- a/libs/soba/src/staging/sparkles.stories.ts
+++ b/libs/soba/src/staging/sparkles.stories.ts
@@ -65,7 +65,7 @@ class DefaultSparklesStory {
 
 export default {
 	title: 'Staging/Sparkles',
-	decorators: storyDecorators(),
+	decorators: storyDecorators() as any,
 } satisfies Meta;
 
 export const Default = storyObject(DefaultSparklesStory, {


### PR DESCRIPTION
- port drei's KeyboardControls to a renderless [keyboardControls] directive in angular-three-soba/controls
- signal-based state with select(), snapshot, and transition-only keyChange output
- per-action reference counting of held keys, up:false fire-on-press, and toggle:true stateful on/off actions
- injectKeyboardControls() inject fn and createKeyboardControls() typed map factory
- unit tests, README section, examples demo scene, and stories for default/fire-on-press/toggle modes